### PR TITLE
修正PushPlus推送地址

### DIFF
--- a/actions/sendMessage.py
+++ b/actions/sendMessage.py
@@ -115,7 +115,7 @@ class Pushplus:
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0'
             }
             res = requests.post(
-                "https://pushplus.hxtrip.com/send", headers=headers, params=params)
+                "https://www.pushplus.plus/send", headers=headers, params=params)
             if res.status_code == 200:
                 return "发送成功"
             else:


### PR DESCRIPTION
由`http://pushplus.hxtrip.com/`切换为`http://pushplus.plus/`
接口代码通用 关注服务号不同
旧push.hxtrip系作者在旅行公司时下挂在公司网络下开发的推送服务
现已转移到http://pushplus.plus/

![image](https://user-images.githubusercontent.com/21352718/149703642-f9d61143-236b-44b8-99aa-d9e40e33c208.png)
