### PR TITLE
fix path bug on linux

### DIFF
--- a/index.py
+++ b/index.py
@@ -31,7 +31,7 @@ sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())  # 设置默认输�
 
 # 检查代码完整性
 try:
-    for i in ("todayLoginService", "actions\\autoSign", "actions\\collection", "actions\\sleepCheck", "actions\\workLog", "actions\\sendMessage", "actions\\teacherSign", "login\\Utils", "login\\casLogin", "login\\iapLogin", "login\\RSALogin", "liteTools"):
+    for i in ("todayLoginService", "actions/autoSign", "actions/collection", "actions/sleepCheck", "actions/workLog", "actions/sendMessage", "actions/teacherSign", "login/Utils", "login/casLogin", "login/iapLogin", "login/RSALogin", "liteTools"):
         i = os.path.normpath(i)  # 路径适配系统
         imp.find_module(i)
 except ImportError as e:


### PR DESCRIPTION
Windows系统同时支持/和\两种路径，而Linux仅支持/一种，建议使用/为

或者可以使用pathlib进行路径拼接

我看到代码中尝试解决多平台路劲兼容问题，不过实际上这个用法是无效的，该方法可以将在Windows中把/转为\\，而不能在Linux中把\\转为/。参考https://docs.python.org/3/library/os.path.html#os.path.normpath

最后十分感谢大佬的脚本