### PR TITLE
修复无法在阿里云函数上发邮件的问题

### DIFF
--- a/actions/sendMessage.py
+++ b/actions/sendMessage.py
@@ -231,7 +231,7 @@ class Smtp:
             mail['Subject'] = Header(title, 'utf-8')
             mail['From'] = formataddr((self.senderName, self.sender), "utf-8")
             smtpObj = smtplib.SMTP()
-            smtpObj.connect(self.host, 25)
+            smtpObj = smtplib.SMTP_SSL(self.host, 465)
             smtpObj.login(self.user, self.key)
             smtpObj.sendmail(self.sender, self.receivers, mail.as_string())
             return("邮件发送成功")


### PR DESCRIPTION
现在smtp开启SSL，可以运行在阿里云函数、腾讯云函数、本地上成功发送邮件