### PR TITLE
Fix Bug：邮件推送消息换行错误

### DIFF
--- a/actions/sendMessage.py
+++ b/actions/sendMessage.py
@@ -222,7 +222,7 @@ class Smtp:
         :param msg: 要发送的消息(自动转为字符串类型)
         :param title: 邮件标题(自动转为字符串类型)"""
         msg = str(msg)
-        msg = msg.replace("\n", "</br>")
+        msg = msg.replace("\n", "<br>")
         title = str(title)
         if not self.configIsCorrect:
             return '无效配置'


### PR DESCRIPTION
修复：关于邮件推送在网易126邮箱不换行、在QQ邮箱多次换行的问题
![image](https://user-images.githubusercontent.com/85266337/167336180-8448cc44-5706-4896-838a-fada276c8157.png)
![image](https://user-images.githubusercontent.com/85266337/167336249-1565c23e-4c51-4f20-afcd-2861b7b8b172.png)
（截图是同一封但是群发的邮件）